### PR TITLE
add internal formatter package for the CLI commands output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,6 @@ go 1.16
 require (
 	github.com/ppapapetrou76/go-testing v0.0.6
 	github.com/stretchr/testify v1.7.0
+	github.com/urfave/cli/v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
@@ -8,11 +11,17 @@ github.com/ppapapetrou76/go-testing v0.0.6 h1:hL0VgDgEHQrVe8w6vR9NWctFfbgKvavh00
 github.com/ppapapetrou76/go-testing v0.0.6/go.mod h1:CfAgJGE1J1BHK4eNQIaOCWJUruDCg+BKh5HcxkFWQZc=
 github.com/r3labs/diff/v2 v2.13.0 h1:wgDu/09BG+X6Kn5eyVDO3mH62x0Twt6C0uYgZuVK+gk=
 github.com/r3labs/diff/v2 v2.13.0/go.mod h1:I8noH9Fc2fjSaMxqF3G2lhDdC0b+JXCfyx85tWFM9kc=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -27,5 +36,6 @@ google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,0 +1,23 @@
+package formatter
+
+import "io"
+
+// Formatter is the interface for all data output formatters.
+type Formatter interface {
+	Format(data interface{}) error
+	Name() string
+}
+
+// New creates the proper formatter based on the given name.
+func New(writer io.Writer, name string) Formatter {
+	switch name {
+	case jsonName:
+		return NewJSON(writer)
+	case yamlName:
+		return NewYAML(writer)
+	case textName:
+		return NewText(writer)
+	default:
+		return NewJSON(writer)
+	}
+}

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,0 +1,42 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ppapapetrou76/go-testing/assert"
+)
+
+func TestNew(t *testing.T) {
+	var b bytes.Buffer
+	tests := []struct {
+		name          string
+		expected      Formatter
+		formatterName string
+	}{
+		{
+			name:     "should create the default formatter (json)",
+			expected: NewJSON(&b),
+		},
+		{
+			name:          "should create the json formatter",
+			expected:      NewJSON(&b),
+			formatterName: "json",
+		},
+		{
+			name:          "should create the yaml formatter",
+			expected:      NewYAML(&b),
+			formatterName: "yaml",
+		},
+		{
+			name:          "should create the text formatter",
+			expected:      NewText(&b),
+			formatterName: "text",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := New(&b, tt.formatterName)
+		assert.That(t, actual).IsEqualTo(tt.expected)
+	}
+}

--- a/internal/formatter/json.go
+++ b/internal/formatter/json.go
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+const (
+	jsonName           = "json"
+	defaultPrefix      = ""
+	defaultIndentation = "  "
+)
+
+// NewJSON acts as the factory for formatter.JSON.
+func NewJSON(writer io.Writer) *JSON {
+	return &JSON{
+		writer:      writer,
+		prefix:      defaultPrefix,
+		indentation: defaultIndentation,
+	}
+}
+
+// JSON formats into text.
+type JSON struct {
+	writer              io.Writer
+	prefix, indentation string
+}
+
+// Name obtains the name of the formatter.
+func (f *JSON) Name() string {
+	return jsonName
+}
+
+// Format formats data as json output.
+func (f *JSON) Format(data interface{}) error {
+	r, err := json.MarshalIndent(data, f.prefix, f.indentation)
+	if err != nil {
+		return fmt.Errorf("json formatter:%w", err)
+	}
+	fmt.Fprintln(f.writer, string(r))
+
+	return nil
+}

--- a/internal/formatter/json_test.go
+++ b/internal/formatter/json_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ppapapetrou76/go-testing/assert"
+)
+
+func TestNewJSON(t *testing.T) {
+	var b bytes.Buffer
+	actual := NewJSON(&b)
+	expected := &JSON{
+		writer:      &b,
+		prefix:      "",
+		indentation: "  ",
+	}
+
+	assert.That(t, actual).IsEqualTo(expected)
+}
+
+func TestJSON_Name(t *testing.T) {
+	assert.That(t, NewJSON(nil).Name()).IsEqualTo("json")
+}
+
+type sampleStruct struct {
+	Field1 string `json:"field_1"`
+	Field2 int    `json:"field_2"`
+}
+
+func TestJSON_Format(t *testing.T) {
+	var b bytes.Buffer
+
+	tests := []struct {
+		name           string
+		formatter      *JSON
+		data           interface{}
+		expectedOutput string
+	}{
+		{
+			name:      "should succeed un-marshaling structure",
+			formatter: NewJSON(&b),
+			data: sampleStruct{
+				Field1: "some-data",
+				Field2: 199,
+			},
+			expectedOutput: `{
+  "field_1": "some-data",
+  "field_2": 199
+}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.formatter.Format(tt.data)
+			assert.ThatError(t, err).IsNil()
+			assert.ThatString(t, b.String()).IsEqualTo(tt.expectedOutput)
+		})
+	}
+}

--- a/internal/formatter/text.go
+++ b/internal/formatter/text.go
@@ -1,0 +1,73 @@
+package formatter
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"text/tabwriter"
+
+	"github.com/ppapapetrou76/go-data-gov-gr-sdk/pkg/util/numbers"
+)
+
+const textName = "text"
+
+// Text is the formatter to format data into readable text.
+type Text struct {
+	writer io.Writer
+}
+
+// NewText acts as the factory for formatter.Text.
+func NewText(writer io.Writer) *Text {
+	return &Text{
+		writer: writer,
+	}
+}
+
+// Format formats data as simple text output.
+func (f *Text) Format(data interface{}) error {
+	t := reflect.TypeOf(data).Kind()
+	//nolint:exhaustive //covered by default switch
+	switch t {
+	case reflect.Slice:
+		v := reflect.ValueOf(data)
+		for i := 0; i < v.Len(); i++ {
+			if i == 0 {
+				d := v.Index(i).Interface()
+				if reflect.TypeOf(d).Kind() == reflect.Struct {
+					w := tabwriter.NewWriter(f.writer, 15, 0, 0, ' ', tabwriter.TabIndent)
+
+					v := reflect.ValueOf(d)
+					typeOfS := v.Type()
+					for i := 0; i < v.NumField(); i++ {
+						fieldName := typeOfS.Field(i).Name
+						min := numbers.Min(len(fieldName), 14)
+						fmt.Fprintf(w, "%s\t", typeOfS.Field(i).Name[0:min])
+					}
+					fmt.Fprintln(w)
+					w.Flush()
+				}
+			}
+			if err := f.Format(v.Index(i).Interface()); err != nil {
+				return err
+			}
+		}
+	case reflect.Struct:
+		w := tabwriter.NewWriter(f.writer, 15, 1, 0, ' ', tabwriter.TabIndent)
+		v := reflect.ValueOf(data)
+		for i := 0; i < v.NumField(); i++ {
+			fmt.Fprintf(w, "%v\t", v.Field(i).Interface())
+		}
+		fmt.Fprintln(w)
+		w.Flush()
+	default:
+
+		return fmt.Errorf("not supported type %+v", t)
+	}
+
+	return nil
+}
+
+// Name obtains the name of the formatter.
+func (f *Text) Name() string {
+	return textName
+}

--- a/internal/formatter/text_test.go
+++ b/internal/formatter/text_test.go
@@ -1,0 +1,93 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ppapapetrou76/go-testing/assert"
+)
+
+func TestNewText(t *testing.T) {
+	var b bytes.Buffer
+	actual := NewText(&b)
+	expected := &Text{
+		writer: &b,
+	}
+
+	assert.That(t, actual).IsEqualTo(expected)
+}
+
+func TestText_Name(t *testing.T) {
+	assert.That(t, NewText(nil).Name()).IsEqualTo("text")
+}
+
+func TestText_Format(t *testing.T) {
+	var b bytes.Buffer
+
+	tests := []struct {
+		name           string
+		formatter      *Text
+		data           interface{}
+		expectedOutput string
+		expectedErr    error
+	}{
+		{
+			name:        "should return an error for un-supported type",
+			formatter:   NewText(&b),
+			data:        "some string",
+			expectedErr: errors.New("not supported type string"),
+		},
+		{
+			name:      "should succeed un-marshaling structure",
+			formatter: NewText(&b),
+			data: sampleStruct{
+				Field1: "some-data",
+				Field2: 199,
+			},
+			expectedOutput: "some-data      199            \n",
+		},
+		{
+			name:      "should succeed un-marshaling slice",
+			formatter: NewText(&b),
+			data: []sampleStruct{
+				{
+					Field1: "some-data",
+					Field2: 199,
+				},
+				{
+					Field1: "some-more-data",
+					Field2: 166,
+				},
+			},
+			expectedOutput: "Field1         Field2         \n" +
+				"some-data      199            \n" +
+				"some-more-data 166            \n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer b.Reset()
+			err := tt.formatter.Format(tt.data)
+			assert.ThatError(t, err).IsSameAs(tt.expectedErr)
+			assert.ThatString(t, b.String()).IsEqualTo(tt.expectedOutput)
+		})
+	}
+}

--- a/internal/formatter/yaml.go
+++ b/internal/formatter/yaml.go
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	yamlName = "yaml"
+)
+
+// NewYAML acts as the factory for formatter.YAML.
+func NewYAML(writer io.Writer) *YAML {
+	return &YAML{
+		writer: writer,
+	}
+}
+
+// YAML formats into yaml.
+type YAML struct {
+	writer io.Writer
+}
+
+// Name obtains the name of the formatter.
+func (f *YAML) Name() string {
+	return yamlName
+}
+
+// Format formats data as yaml output.
+func (f *YAML) Format(data interface{}) error {
+	r, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("yaml formatter:%w", err)
+	}
+	fmt.Fprintln(f.writer, string(r))
+
+	return nil
+}

--- a/internal/formatter/yaml_test.go
+++ b/internal/formatter/yaml_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ppapapetrou76/go-testing/assert"
+)
+
+func TestNewYAML(t *testing.T) {
+	var b bytes.Buffer
+	actual := NewYAML(&b)
+	expected := &YAML{
+		writer: &b,
+	}
+
+	assert.That(t, actual).IsEqualTo(expected)
+}
+
+func TestYAML_Name(t *testing.T) {
+	assert.That(t, NewYAML(nil).Name()).IsEqualTo("yaml")
+}
+
+func TestYAML_Format(t *testing.T) {
+	var b bytes.Buffer
+
+	tests := []struct {
+		name           string
+		formatter      *YAML
+		data           interface{}
+		expectedOutput string
+	}{
+		{
+			name:      "should succeed un-marshaling structure",
+			formatter: NewYAML(&b),
+			data: sampleStruct{
+				Field1: "some-data",
+				Field2: 199,
+			},
+			expectedOutput: `field1: some-data
+field2: 199
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.formatter.Format(tt.data)
+			assert.ThatError(t, err).IsNil()
+			assert.ThatString(t, b.String()).IsEqualTo(tt.expectedOutput)
+		})
+	}
+}


### PR DESCRIPTION
Adds the following formatters that will be used by the CLI commands

- Json
- Yaml
- Text ( without the usage of go templates for now )